### PR TITLE
LCP array and tagging repeats clarified.

### DIFF
--- a/lib/libhrc.js
+++ b/lib/libhrc.js
@@ -1,5 +1,33 @@
-var getLRS = require("../lib/lrcs.js");
+var getLCPArray = require("../lib/lrcs.js");
 var tagRepeats = require("../lib/tagRepeats.js");
 
-module.exports.findLRS = getLRS;
+
+var naive_compress = function(s, showNum=false, multiplier="", left_tag="", right_tag="") {
+  var lcp_array = getLCPArray(s);
+  //console.log(lcp_array);
+  if (lcp_array.length > 0) {
+    // Start from the longest LCP and find the first the compresses the original
+    // string.
+    var compressed_len = s.length;
+    var i = lcp_array.length - 1;
+    var lrs = null;
+    var newDoc = null;
+    while(i >= 0 && compressed_len >= s.length) {
+      lrs = lcp_array[i];
+      if (lrs.length > 0) {
+        newDoc = tagRepeats(
+          lrs, s, showNum, multiplier, left_tag, right_tag
+        );
+        compressed_len = newDoc.length;
+      }
+      i--;
+    }
+    return newDoc;
+  } else {
+    return s;
+  }
+}
+
+module.exports.getLCPArray = getLCPArray;
 module.exports.tagRepeatedPhrases = tagRepeats;
+module.exports.naive_compress = naive_compress;

--- a/lib/lrcs.js
+++ b/lib/lrcs.js
@@ -32,14 +32,23 @@ var findTokenPositions = function(str) {
   return tokenIndices;
 }
 
-var getLongestRepeatedSubString = function(str) {
+var getLCPArray = function(str) {
   // Iterates through a suffix array and finds the longest common prefix.
+
+  if (str.length === 0) {
+    return [];
+  }
+
+  // Split the sentence into tokens.
   var tokenList = str.split(" ");
   if (tokenList.length <= 1) {
     return "";
   }
+
+  // Get positions of each token in the original string.
   var positions = findTokenPositions(str);
 
+  // Create the shuffix array by sorting it.
   var shuffixArray = Array.apply(null, Array(tokenList.length))
     .map(function (_, i) {return i;});
   shuffixArray.sort(function(a, b) {
@@ -53,28 +62,32 @@ var getLongestRepeatedSubString = function(str) {
       return 0;
     }
   });
-  //console.log(shuffixArray);
 
-  var best = "";  // will hold longest, repeated, non-overlapping substring.
-
+  // Build LCP array (longest common prefix)
+  var lcp_array = [];
   for(var i = 1; i < shuffixArray.length; i++) {
     var sh1 = shuffixArray[i-1];
     var sh2 = shuffixArray[i];
 
-    var distance = Math.abs(positions[sh1] - positions[sh2]);
-
     var tokensMatched = longestCommonPrefix(sh1, sh2, tokenList);
-    var matchLength = tokenList.slice(sh1, sh1+tokensMatched).reduce(function(a, b) {
-      return a + 1 + b.length;
-    }, -1);
+    var lcp = tokenList.slice(sh1, sh1+tokensMatched).join(" ");
 
-    // check if match is consecutive between these 2 shuffixes.
-    if((matchLength > best.length) && (matchLength+1 === distance)) {
-      best = tokenList.slice(sh1, sh1+tokensMatched).join(" ");
+    if (lcp.length > 0) {
+      lcp_array.push(lcp);
     }
   }
 
-  return best;
+  lcp_array.sort(function(a, b) {
+    if (a.length < b.length) {
+      return -1;
+    } else if (a.length > b.length) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+  return lcp_array;
 };
 
-module.exports = getLongestRepeatedSubString;
+module.exports = getLCPArray;

--- a/lib/tagRepeats.js
+++ b/lib/tagRepeats.js
@@ -8,27 +8,19 @@ var findAllIndices = function(arr, elem) {
   return indices;
 }
 
-var tagRepeats = function(pattern, doc, tag=true, multiplier=' x', tagStart='<', tagEnd='> ') {
-  // Using Rabin Karp, find the pattern in the document and tag each
-  // repeated instance of the pattern.
-  //console.log(pattern);
+var findRuns = function(pattern, doc) {
   var matches = findAllIndices(doc, pattern);
-  //console.log(matches);
 
-  // 3 things can happen:
-  // - 1 match.
-  //   - just return doc. No change.
-  // - multiple matches.
-  //   - compress only repeats
-  // - no matches.
-  //   - just return doc. No change.
-  if (matches.length === 0 || matches.length === 1) {
+  // Returned structure:
+  // list of tuples where each tuple is the start of the run and the number
+  // of times that run is repeated.
+  if (matches.length === 0) {
     return doc;
+  } else if (matches.length === 1) {
+    return [{start: matches[0], count: 1}];
   } else {
     // collect "runs"
-    // Populate the new string up until the first match
-    var newDoc = doc.slice(0, matches[0]);
-
+    var runs = [];
     var runStart = matches[0];
     var runCount = 1;
     for(var i = 1; i < matches.length; i++) {
@@ -37,36 +29,50 @@ var tagRepeats = function(pattern, doc, tag=true, multiplier=' x', tagStart='<',
         // Continue the run
         runCount++;
       } else {
-        if (runCount > 1 && tag) {
-          // If run longer than 1, print the count.
-          newDoc += tagStart + pattern + multiplier + runCount + tagEnd;
-        } else {
-          // Don't print the count.
-          newDoc += pattern + ' ';
-        }
-        // Print characters not part of the pattern up until the next match.
-        newDoc += doc.slice(matches[i-1]+pattern.length+1, matches[i]);
+        // Log the run.
+        runs.push({start: runStart, count: runCount});
+
+        // Restart run counting
         runStart = matches[i];
         runCount = 1;
       }
     }
-    // State of the new doc:
-    // - The last run is never printed.
-    //    - If there's one run, it still hasn't been printed.
+    // State:
+    // - The last run is never logged.
+    //    - If there's one run, it still hasn't been logged.
     // - for n number of runs where n > 1, the last is not printed so we better
     //   make sure we handle it outside of this for loop.
+    runs.push({start: runStart, count: runCount});
   }
 
-  // Check if we left a run that continued to the end of the string.
-  if (runCount > 1 && tag) {
-    newDoc += tagStart + pattern + multiplier + runCount + tagEnd;
-  } else {
-    newDoc += pattern;
+  return runs;
+};
+
+var tagRuns = function(runs, pattern, doc, showNum, multiplier, tagStart, tagEnd) {
+  var lastPos = 0;
+  var newDoc = '';
+  for (run of runs) {
+    newDoc += doc.slice(lastPos, run.start);
+
+    if (showNum && run.count > 1) {
+      newDoc += tagStart + pattern + multiplier + run.count + tagEnd + " ";
+    } else {
+      newDoc += pattern + " ";
+    }
+
+    lastPos = run.start + run.count*(pattern.length + 1);
   }
-  // Print characters not part of the pattern up until the end of the doc
-  newDoc += doc.slice(matches[matches.length - 1]+pattern.length+1);
+
+  if (lastPos < doc.length) {
+    newDoc += doc.slice(lastPos);
+  }
 
   return newDoc.trim();
-};
+}
+
+var tagRepeats = function(pattern, doc, showNum, multiplier, tagStart, tagEnd) {
+  var runs = findRuns(pattern, doc);
+  return tagRuns(runs, pattern, doc, showNum, multiplier, tagStart, tagEnd);
+}
 
 module.exports = tagRepeats;

--- a/test/simpleStringTest.js
+++ b/test/simpleStringTest.js
@@ -1,33 +1,85 @@
+const assert = require('assert');
 var libhrc = require("../lib/libhrc.js");
 
 
-var testString = function(s, tag=true, multiplier=' x', left_tag='<', right_tag='> ') {
+var testString = function(s, truth=null, showNum=true, multiplier=' x', left_tag='<', right_tag='>') {
   console.log("Test: '" + s + "'");
-  var lrs = libhrc.findLRS(s);
-  console.log("LRS: '" + lrs + "'");
-  if (lrs.length > 0) {
-    console.log("Result: '" + libhrc.tagRepeatedPhrases(lrs, s, tag, multiplier, left_tag, right_tag) + "'");
+  var newDoc = libhrc.naive_compress(s, showNum, multiplier, left_tag, right_tag);
+  console.log("Result: '" + newDoc + "'");
+  if (truth) {
+    assert.deepStrictEqual(newDoc, truth);
   }
 }
 
 // Twitch chat characteristics:
 // - trimmed (no white space(s) at beginning and end)
 // - single spaces between words
-testString("simple repeat simple repeat simple repeat");
-testString("extra words at the start simple repeat simple repeat simple repeat");
-testString("simple repeat simple repeat simple repeat extra words at the end");
-testString("wrapped at start simple repeat simple repeat simple repeat and at the end")
-testString("simple repeat simple repeat simple repeat. <-- period messes things up!");
-testString("Capitalization not handled capitalization Not Handled!");
-testString("you youngings");
-testString("this is the best");
-testString("kung fu fun");
-testString("check it out, no tags: repeated message but no tags repeated message but no tags", false);
-testString("free coins free coins free coins free coins free coins", true, " ↑");
-testString("Si se puede Si se puede Si se puede", true, ' x', '¡', '!');
-testString("Duck Duck Goose Duck");
-testString("");
-testString("oneword");
-testString("multi run multi run INTERRUPTION multi run multi run multi run");
-testString("y y z y y y BUT THIS WORKS, interruption is lexicographically greater than.");
-testString("KKona 🎸 KKona 🎸 KKona emojis baby");
+testString(
+  "simple repeat simple repeat simple repeat",
+  "<simple repeat x3>"
+);
+testString(
+  "extra words at the start simple repeat simple repeat simple repeat",
+  "extra words at the start <simple repeat x3>"
+);
+testString(
+  "simple repeat simple repeat simple repeat extra words at the end",
+  "<simple repeat x3> extra words at the end"
+);
+testString(
+  "wrapped at start simple repeat simple repeat simple repeat and at the end",
+  "wrapped at start <simple repeat x3> and at the end"
+);
+testString(
+  "simple repeat simple repeat simple repeat. <-- period messes things up!",
+  "simple <repeat simple x2> repeat. <-- period messes things up!"
+);
+testString(
+  "Capitalization not handled capitalization Not Handled!",
+  "Capitalization not handled capitalization Not Handled!"
+);
+testString(
+  "you youngings",
+  "you youngings"
+);
+testString(
+  "this is the best",
+  "this is the best"
+);
+testString(
+  "kung fu fun",
+  "kung fu fun"
+);
+testString(
+  "check it out, no tags: repeated message but no tags repeated message but no tags",
+  "check it out, no tags: repeated message but no tags",
+  false, "", "", "");
+testString(
+  "free coins free coins free coins free coins free coins",
+  "<free coins ↑5>",
+  true, " ↑");
+testString(
+  "Si se puede Si se puede Si se puede",
+  "¡Si se puede x3!",
+  true, ' x', '¡', '!');
+testString(
+  "Duck Duck Goose Duck",
+  "<Duck x2> Goose Duck"
+);
+testString("", "");
+testString(
+  "oneword",
+  "oneword"
+);
+testString(
+  "multi run multi run INTERRUPTION multi run multi run multi run",
+  "<multi run x2> INTERRUPTION <multi run x3>"
+);
+testString(
+  "y y z y y y interruption is lexicographically greater than.",
+  "<y x2> z <y x3> interruption is lexicographically greater than."
+);
+testString(
+  "KKona 🎸 KKona 🎸 KKona emojis baby",
+  "KKona <🎸 KKona x2> emojis baby"
+);


### PR DESCRIPTION
* BUG FIX: lexicographical sort in suffix array not versatile enough to find consecutive repeated substrings.
* naive compress helper function: finds longest common prefix that reduces length of string.
* shuffix array __does not__ check for consecutive/overlapping repeats. Only returns LCP array.
* tagging repeats performs in _O_(_n_): finds the where and how long runs are and loops again to replace substrings
* asserts in test
* default args do not tag repeats